### PR TITLE
Arrow points to right when sidebar navigation is collapsed

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -22,7 +22,11 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={classNames(styles.icon)}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -137,5 +137,9 @@
 
   @media (min-width: breakpoint.$desktop) {
     display: flex;
+
+    &.isCollapsed {
+      transform: rotate(180deg);
+    }
   }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,9 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={`${styles.collapseMenuItem} ${
+                isSidebarCollapsed ? styles.isCollapsed : ""
+              }`}
             />
           </ul>
         </nav>


### PR DESCRIPTION
When the sidebar navigation is collapsed the arrow of the “Collapse” button now points to the right.

Added `isCollapsed` css class to handle this state